### PR TITLE
Patch1

### DIFF
--- a/scripts/source/DevourmentDisability.psc
+++ b/scripts/source/DevourmentDisability.psc
@@ -56,12 +56,8 @@ Event onEffectFinish(Actor akTarget, Actor akCaster)
 		prey.unequipShout(DummyShout)
 		prey.removeSpell(DummySpell)
 		prey.removeShout(DummyShout)
-		if storedSpell
-			prey.equipSpell(storedSpell, 2)
-		endIf
-		if storedShout
-			prey.equipShout(storedShout)
-		endIf
+		prey.equipSpell(storedSpell, 2)
+		prey.equipShout(storedShout)
 	endIf
 	
 

--- a/scripts/source/DevourmentPlayerAlias.psc
+++ b/scripts/source/DevourmentPlayerAlias.psc
@@ -254,7 +254,7 @@ EndFunction
 
 Function StartPlayerStruggle()
 	if !PlayerRef.HasSpell(PlayerStruggleSpell)
-		PlayerRef.AddSpell(PlayerStruggleSpell)
+		PlayerRef.AddSpell(PlayerStruggleSpell, false)
 	endIf
 EndFunction
 

--- a/scripts/source/HelperSpellEffect.psc
+++ b/scripts/source/HelperSpellEffect.psc
@@ -34,11 +34,11 @@ Function castNow()
 	endIf
 	
 	if TargetSpellToAdd != none
-		target.addSpell(TargetSpellToAdd)
+		target.addSpell(TargetSpellToAdd, false)
 	endif
 	
 	if CasterSpellToAdd != none
-		caster.addSpell(CasterSpellToAdd)
+		caster.addSpell(CasterSpellToAdd, false)
 	endif
 	
 	if DispelMe


### PR DESCRIPTION
Scale remains to the size of prey in devourmentmanager
Removed some notifications
Add reformation skull when digestion is finished so less duplicate skulls happen.
If / Else checks for StoredSpell / StoredShout in DevourmentDisability aren't needed
ExpelRemains won't defecate if the pred is currently prey. 